### PR TITLE
FIX: tk98875, in some contexts scrollTo is not the last to run and set page scroll Y on page load

### DIFF
--- a/js/scrollto.js
+++ b/js/scrollto.js
@@ -1,31 +1,26 @@
 if($) {
 	$(document).ready(function() {
-		
-		if($.cookie) {
-			var page_y = $.cookie("scrollTo_page_y");
-			var page_url = $.cookie("scrollTo_url");
-			//console.log(page_y,page_url);
-			
-			if(page_y>0 && document.location.href.indexOf(page_url)>-1 ) {
-				$(document).scrollTop(page_y);	
-			}	
-			
-			
-		}
-		
+		setTimeout(
+			function() {
+				if($.cookie) {
+					var page_y = $.cookie("scrollTo_page_y");
+					var page_url = $.cookie("scrollTo_url");
+					//console.log(page_y,page_url);
+
+					if(page_y>0 && document.location.href.indexOf(page_url)>-1 ) {
+						$(document).scrollTop(page_y);
+					}
+				}
+			},
+			0
+		);
 	});
-	
+
 	$(window).on('unload', function() {
-		
 		var page_y = $(document).scrollTop();
-		//console.log(page_y);
 		if($.cookie) {
-		
 			$.cookie("scrollTo_page_y", page_y, { expires: 1, path: '/' });	
 			$.cookie("scrollTo_url", document.location.href.split('?')[0], { expires: 1, path: '/' });
-			
-		}	
+		}
 	});
-	
 }
-


### PR DESCRIPTION
This fix wraps scrollTo in a setTimeout(…, 0) to put it at the end of the execution queue
+ whitespace & commented-out console.log() cleanup